### PR TITLE
Set visibility permissions based on 🧵 reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Follow the
 instructions from the discord.py docs.
 * Name your test bot whatever you want, like "Jaxlyn's Test Bot".
 * No need to make it a "Public Bot".
+* _Do_ enable "Server Members Intent" (in "Bot" settings).
 * Do _not_ check "Require OAuth2 Public Grant".
 * Copy the *Token* (_not_ the ~~*Client Secret*~~).
 

--- a/escape_roomba/event_logger.py
+++ b/escape_roomba/event_logger.py
@@ -27,8 +27,8 @@ class EventLogger:
     #
 
     async def _on_connect(self):
-        _logger.info('Connected to Discord:\n'
-                     f'    {self._discord.ws.gateway}')
+        _logger.info('\n    Connected to Discord:'
+                     f'\n      {self._discord.ws.gateway}')
 
     async def _on_disconnect(self):
         _logger.info(f'Disconnected from Discord')
@@ -38,109 +38,109 @@ class EventLogger:
 
     async def _on_ready(self):
         c = self._discord
-        _logger.info(f'Ready in {len(c.guilds)} servers (as {c.user}):' +
-                     ''.join(f'\n    "{g}"' for g in c.guilds))
+        _logger.info(f'\n    Ready in {len(c.guilds)} servers as {c.user}:' +
+                     ''.join(f'\n      "{g}"' for g in c.guilds))
         invite_url = discord.utils.oauth_url(
             (await c.application_info()).id,
             discord.Permissions(
-                manage_channels=True,
-                add_reactions=True,
-                read_messages=True,
-                send_messages=True,
-                manage_messages=True,
-                read_message_history=True,
-                manage_roles=True))
-        _logger.info('Open this link to add this bot to more servers:\n'
-                     f'    {invite_url}')
+                manage_channels=True, add_reactions=True, read_messages=True,
+                send_messages=True, manage_messages=True,
+                read_message_history=True, manage_roles=True))
+        _logger.info('\n    Open this link to add this bot to more servers:'
+                     f'\n      {invite_url}')
 
     async def _on_guild_join(self, guild):
-        _logger.info(f'Joined Discord guild (server) "{guild}"')
+        _logger.info(f'\n    Joined Discord guild (server) "{guild}"')
 
     async def _on_guild_remove(self, guild):
-        _logger.info(f'Removed from Discord guild (server) "{guild}"')
+        _logger.info(f'\n    Removed from Discord guild (server) "{guild}"')
 
     async def _on_error(self, event, *args, **kwargs):
-        _logger.exception(f'Exception in "{event}" handler:')
+        _logger.exception(f'\nException in "{event}" handler:')
 
     #
     # Debug-only logging listeners for all message types.
     #
 
     async def _debug_on_message(self, m):
-        _logger.debug(f'Post message\n    {self._fobj(m=m)}')
+        _logger.debug(f'Received message\n    {self._fobj(m=m)}')
 
     async def _debug_on_message_delete(self, m):
-        _logger.debug(f'Delete message\n    {self._fobj(m=m)}')
+        _logger.debug(f'\n    Delete: {self._fobj(m=m)}')
 
     async def _debug_on_bulk_message_delete(self, ms):
-        _logger.debug(f'Delete {len(ms)} messages:\n' +
-                      '\n'.join(f'    {self._fobj(m=m)}' for m in ms))
+        _logger.debug(f'\n    Bulk delete of {len(ms)} messages:\n' +
+                      '\n'.join(f'      {self._fobj(m=m)}' for m in ms))
 
     async def _debug_on_raw_message_delete(self, p):
-        _logger.debug(f'Raw delete message\n    ' +
+        _logger.debug(f'\n    Raw delete: ' +
                       self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id))
 
     async def _debug_on_raw_bulk_message_delete(self, p):
         _logger.debug(
-            f'Raw delete {len(p.message_ids)} messages in '
-            f'{self._fobj(g=p.guild_id, c=p.channel_id)}:\n'
-            '\n'.join(f'    {self._fobj(m=m)}' for m in p.message_ids))
+            f'\n    Raw bulk delete of {len(p.message_ids)} messages in '
+            f'{self._fobj(g=p.guild_id, c=p.channel_id)}:'
+            ''.join(f'\n      {self._fobj(m=m)}' for m in p.message_ids))
 
     async def _debug_on_message_edit(self, b, a):
-        _logger.debug('Edit message\n'
-                      f'    was: {self._fobj(m=b)}\n'
-                      f'    now: {self._fobj(m=a)}')
+        _logger.debug('Message edit:'
+                      f'\n    Old {self._fobj(m=b)}\n'
+                      f'\n    New {self._fobj(m=a)}')
 
     async def _debug_on_raw_message_edit(self, p):
-        _logger.debug('Raw edit message\n    ' +
-                      self._fobj(c=p.channel_id, m=p.message_id,
-                                 u=int(p.data.get('author', {}).get('id', 0))))
+        _logger.debug(
+            '\n    Raw edit: ' +
+            self._fobj(c=p.channel_id, m=p.message_id,
+                       u=int(p.data.get('author', {}).get('id', 0))))
 
     async def _debug_on_reaction_add(self, r, u):
-        _logger.debug(f'Add [{r.emoji}] {self._fobj(u=u)} on\n    ' +
+        _logger.debug(f'\n    Add [{r.emoji}] {self._fobj(u=u)} to\n    ' +
                       self._fobj(m=r.message))
 
     async def _debug_on_raw_reaction_add(self, p):
-        _logger.debug(f'Raw add [{p.emoji}] {self._fobj(u=p.user_id)} on\n'
-                      f'    ' +
-                      self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id))
+        _logger.debug(
+            f'\n    Raw add [{p.emoji}] '
+            f'{self._fobj(u=p.user_id)} to\n      ' +
+            self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id))
 
     async def _debug_on_reaction_remove(self, r, u):
-        _logger.debug(f'Remove [{r.emoji}] {self._fobj(u=u)} on\n    ' +
-                      self._fobj(m=r.message))
+        _logger.debug(
+            f'\n    Remove [{r.emoji}] {self._fobj(u=u)} from\n    ' +
+            self._fobj(m=r.message))
 
     async def _debug_on_raw_reaction_remove(self, p):
         _logger.debug(
-            f'Raw remove [{p.emoji}] {self._fobj(u=p.user_id)} on\n'
-            f'    {self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id)}')
+            f'\n    Raw remove [{p.emoji}] '
+            f'{self._fobj(u=p.user_id)} from\n      ' +
+            self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id))
 
     async def _debug_on_reaction_clear(self, m, rs):
-        _logger.debug(f'Clear all {len(rs)} reactions from\n'
-                      f'    {self._fobj(m=m)}:' +
-                      '\n'.join(f'    {r.count}x {r.emoji}' for r in rs))
+        _logger.debug(f'\n    Clear all reactions from {self._fobj(m=m)}:' +
+                      ''.join(f'\n      {r.count}x [{r.emoji}]' for r in rs))
 
     async def _debug_on_raw_reaction_clear(self, p):
-        _logger.debug(f'Raw clear all reactions from\n    ' +
+        _logger.debug('\n    Raw clear all reactions on\n      ' +
                       self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id))
 
     async def _debug_on_reaction_clear_emoji(self, r):
-        _logger.debug(f'Clear [{r.emoji}] from\n    {self._fobj(m=r.message)}')
+        _logger.debug(f'\n    Clear {r.count}x [{r.emoji}] on'
+                      f'\n      {self._fobj(m=r.message)}')
 
     async def _debug_on_raw_reaction_clear_emoji(self, p):
-        _logger.debug(f'Raw clear [{p.emoji}] from\n    ' +
+        _logger.debug(f'\n    Raw clear [{p.emoji}] on\n      ' +
                       self._fobj(g=p.guild_id, c=p.channel_id, m=p.message_id))
 
     async def _debug_on_guild_channel_delete(self, c):
-        _logger.debug(f'Channel delete {self._fobj(c=c)}')
+        _logger.debug(f'Delete {self._fobj(c=c)}')
 
     async def _debug_on_guild_channel_create(self, c):
-        _logger.debug(f'Channel create {self._fobj(c=c)}')
+        _logger.debug(f'Create {self._fobj(c=c)}')
 
     async def _debug_on_guild_channel_update(self, b, a):
-        _logger.debug(f'Channel update {self._fobj(c=b)}')
+        _logger.debug(f'Update {self._fobj(c=b)}')
 
     async def _debug_on_guild_available(self, g):
         _logger.debug(f'Server available {self._fobj(g=g)}')
 
     async def _debug_on_guild_unavailable(self, g):
-        _logger.debug(f'Server UNavailable {self._fobj(g=g)}')
+        _logger.debug(f'Server unavailable {self._fobj(g=g)}')

--- a/escape_roomba/format_util.py
+++ b/escape_roomba/format_util.py
@@ -26,48 +26,76 @@ def fid(id):
             f'{(id & 0xFFF) or ""}>')
 
 
-def fobj(client=None, g=None, c=None, u=None, m=None):
+def fobj(client=None, g=None, c=None, u=None, r=None, m=None, p=None):
     """Pretty-formats Discord objects associated with some action.
 
-    Args: (all may be None)
-        client: discord.Client for lookup
+    Args: (may be None to infer if possible, '' to suppress)
+        client: discord.Client or discord.Guild for lookup
         g: discord.Guild, int guild ID, or None
-        c: discord.GuildChannel, .PrivateChannel, int channel ID, or None
-        u: discord.User, .Member, int user ID, or None
+        c: discord.GuildChannel, PrivateChannel, int channel ID, or None
+        u: discord.User, Member, int user ID, or None
+        r: discord.Role, int role ID, or None
         m: discord.Message, int message ID, or None
+        p: discord.Permissions, PermissionOverwrites, user dict, int, or None
 
     Returns:
         A string describing all the given parameters, e.g.
         '"guild" #channel (user#1234) "message text"'
     """
 
-    # Look up raw IDs, if possible.
-    if client and isinstance(g, int):
-        g = client.get_guild(g) or g
-    if client and isinstance(c, int):
-        c = client.get_channel(c) or c
-    if client and isinstance(u, int):
-        u = client.get_user(u) or u
+    # Look up int IDs using the client, if possible.
+    def lookup(a, m, b):
+        return getattr(a, m, lambda x: x)(b) if isinstance(b, int) else b
 
-    # Get embedded values from objects, if present.
-    if hasattr(m, 'guild'):    # Message-like
-        g = m.guild or g
-    if hasattr(m, 'channel'):  # Message-like
-        c = m.channel or c
-    if hasattr(m, 'author'):   # Message-like
-        u = m.author or u
-    if hasattr(u, 'guild'):    # Member-like
-        g = u.guild or g
-    if hasattr(c, 'guild'):    # GuildChannel-like
-        g = c.guild or g
+    g = lookup(client, 'get_guild', g)
+    c = lookup(client, 'get_channel', c)
+    u = lookup(client, 'get_user', u)
+    u = lookup(client, 'get_member', u)  # (if using Guild for lookup)
+
+    # Get the guild from object properties, if present.
+    if g is None or isinstance(g, int):
+        g = (m.guild if hasattr(m, 'guild') else     # Message-like
+             u.guild if hasattr(u, 'guild') else     # Member-like
+             c.guild if hasattr(c, 'guild') else g)  # GuildChannel-like
+
+    # Look up int IDs using the guild, if available.
+    c = lookup(g, 'get_channel', c)
+    u = lookup(g, 'get_member', u)
+    r = lookup(g, 'get_role', r)
+
+    # Look up values from the message, if available.
+    c = m.channel if c is None and hasattr(m, 'channel') else c
+    u = m.author if u is None and hasattr(m, 'author') else u
 
     # Accumulate output that will be assembled with spaces.
-    # The final format will be part or all of this:
+    # Final output will be a subset of this:
+    #   "message text" <@user> #channel (Guild)
     out = []
-    if hasattr(g, 'name'):     # Guild-like
-        out.append(f'"{g.name}"')
-    elif g:
-        out.append(f'g={fid(g)}')
+
+    def abbreviate(text):
+        text = ' '.join((text or '').split())  # Normalize spaces.
+        return text[:15].strip() + ' ...' if len(text) > 15 else text
+
+    if hasattr(m, 'content'):  # Message-like
+        text = abbreviate(m.content)
+        out.append(f'"{text or ""}"')
+        for e in m.embeds if hasattr(m, 'embeds') else []:
+            text = abbreviate(e.title or e.description)
+            out.append(f'E[{text}]' if text else '[empty embed]')
+    elif m:
+        out.append(fid(m).replace('<', '<m:'))
+
+    if hasattr(u, 'name') and hasattr(u, 'discriminator'):  # User/Member-like
+        out.append(f'<@{u.name}#{u.discriminator}>')
+    elif hasattr(u, 'name'):
+        out.append(f'<@{u.name.strip("@")}>')  # Also allow Role-like
+    elif u:
+        out.append(fid(u).replace('<', '<@'))
+
+    if hasattr(r, 'name'):
+        out.append(f'<@{r.name.strip("@")}>')  # Role-like
+    elif r:
+        out.append(fid(r).replace('<', '<@&'))
 
     if hasattr(c, 'me') and hasattr(c, 'recipient'):  # DMChannel-like
         out.append(f'[{c.me} => {c.recipient}]')
@@ -76,26 +104,25 @@ def fobj(client=None, g=None, c=None, u=None, m=None):
     elif hasattr(c, 'name'):  # GuildChannel-like
         out.append(f'#{c.name}')
     elif c:
-        out.append(f'c={fid(c)}')
+        out.append(fid(c).replace('<', '<#'))
 
-    if hasattr(u, 'name') and hasattr(u, 'discriminator'):  # User/Member-like
-        out.append(f'({u.name}#{u.discriminator})')
-    elif u:
-        out.append(f'u={fid(u)}')
+    if hasattr(g, 'name'):  # Guild-like
+        out.append(f'({g.name})')
+    elif g:
+        out.append(fid(g).replace('<', '<g:'))
 
-    def abbreviate(text):
-        text = ' '.join((text or '').split())  # Normalize spaces.
-        return text[:20].strip() + ' ...' if len(text) > 20 else text
-
-    if hasattr(m, 'content'):  # Message-like
-        if out:
-            out[-1] = out[-1] + ':'
-        text = abbreviate(m.content)
-        out.append(f'"{text}"' if text else '[no content]')
-        for e in m.embeds if hasattr(m, 'embeds') else []:
-            text = abbreviate(e.title or e.description)
-            out.append(f'E[{text}]' if text else '[empty embed]')
-    elif m:
-        out.append(f'm={fid(m)}')
+    if hasattr(p, 'items'):  # user/overwrites dict
+        out.append('\n'.join(
+            f'{fobj(p=v)} for {fobj(u=k, g="")}' for k, v in p.items()) or
+            '(no user overwrites)')
+    elif hasattr(p, 'pair'):  # PermissionOverwrites-like
+        out.append(
+            ', '.join(f'{k}={"NY"[v]}' for k, v in sorted(p) if v is not None)
+            or '(no overwrites)')
+    elif hasattr(p, 'value'):  # Permissions-like
+        out.append(', '.join(f'{k}' for k, v in sorted(p) if v) or
+                   '(no permissions)')
+    elif p:
+        out.append(fobj(p=discord.Permissions(p)))
 
     return ' '.join(out) if out else '(None)'

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,7 +80,7 @@ description = "A Python wrapper for the Discord API"
 name = "discord.py"
 optional = false
 python-versions = ">=3.5.3"
-version = "1.4.1"
+version = "1.5.0"
 
 [package.dependencies]
 aiohttp = ">=3.6.0,<3.7.0"
@@ -117,14 +117,6 @@ version = "4.0.2"
 build = ["twine", "wheel", "blurb"]
 docs = ["sphinx"]
 test = ["pytest", "pytest-cov"]
-
-[[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
-name = "more-itertools"
-optional = false
-python-versions = ">=3.5"
-version = "8.5.0"
 
 [[package]]
 category = "main"
@@ -187,12 +179,11 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "6.0.2"
+version = "6.1.1"
 
 [package.dependencies]
 attrs = ">=17.4.0"
 iniconfig = "*"
-more-itertools = ">=4.0.0"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.8.2"
@@ -238,7 +229,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.9.27"
+version = "2020.10.11"
 
 [[package]]
 category = "dev"
@@ -262,7 +253,7 @@ description = "Yet another URL library"
 name = "yarl"
 optional = false
 python-versions = ">=3.5"
-version = "1.5.1"
+version = "1.6.0"
 
 [package.dependencies]
 idna = ">=2.0"
@@ -312,8 +303,8 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 "discord.py" = [
-    {file = "discord.py-1.4.1-py3-none-any.whl", hash = "sha256:98ea3096a3585c9c379209926f530808f5fcf4930928d8cfb579d2562d119570"},
-    {file = "discord.py-1.4.1.tar.gz", hash = "sha256:f9decb3bfa94613d922376288617e6a6f969260923643e2897f4540c34793442"},
+    {file = "discord.py-1.5.0-py3-none-any.whl", hash = "sha256:3acb61fde0d862ed346a191d69c46021e6063673f63963bc984ae09a685ab211"},
+    {file = "discord.py-1.5.0.tar.gz", hash = "sha256:e71089886aa157341644bdecad63a72ff56b44406b1a6467b66db31c8e5a5a15"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -326,10 +317,6 @@ iniconfig = [
 mock = [
     {file = "mock-4.0.2-py3-none-any.whl", hash = "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0"},
     {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
-]
-more-itertools = [
-    {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
-    {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
 ]
 multidict = [
     {file = "multidict-4.7.6-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000"},
@@ -371,8 +358,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.0.2-py3-none-any.whl", hash = "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40"},
-    {file = "pytest-6.0.2.tar.gz", hash = "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"},
+    {file = "pytest-6.1.1-py3-none-any.whl", hash = "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9"},
+    {file = "pytest-6.1.1.tar.gz", hash = "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
@@ -383,27 +370,33 @@ pytest-mock = [
     {file = "pytest_mock-3.3.1-py3-none-any.whl", hash = "sha256:024e405ad382646318c4281948aadf6fe1135632bea9cc67366ea0c4098ef5f2"},
 ]
 regex = [
-    {file = "regex-2020.9.27-cp27-cp27m-win32.whl", hash = "sha256:d23a18037313714fb3bb5a94434d3151ee4300bae631894b1ac08111abeaa4a3"},
-    {file = "regex-2020.9.27-cp27-cp27m-win_amd64.whl", hash = "sha256:84e9407db1b2eb368b7ecc283121b5e592c9aaedbe8c78b1a2f1102eb2e21d19"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5f18875ac23d9aa2f060838e8b79093e8bb2313dbaaa9f54c6d8e52a5df097be"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ae91972f8ac958039920ef6e8769277c084971a142ce2b660691793ae44aae6b"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9a02d0ae31d35e1ec12a4ea4d4cca990800f66a917d0fb997b20fbc13f5321fc"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ebbe29186a3d9b0c591e71b7393f1ae08c83cb2d8e517d2a822b8f7ec99dfd8b"},
-    {file = "regex-2020.9.27-cp36-cp36m-win32.whl", hash = "sha256:4707f3695b34335afdfb09be3802c87fa0bc27030471dbc082f815f23688bc63"},
-    {file = "regex-2020.9.27-cp36-cp36m-win_amd64.whl", hash = "sha256:9bc13e0d20b97ffb07821aa3e113f9998e84994fe4d159ffa3d3a9d1b805043b"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f1b3afc574a3db3b25c89161059d857bd4909a1269b0b3cb3c904677c8c4a3f7"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5533a959a1748a5c042a6da71fe9267a908e21eded7a4f373efd23a2cbdb0ecc"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:1fe0a41437bbd06063aa184c34804efa886bcc128222e9916310c92cd54c3b4c"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:c570f6fa14b9c4c8a4924aaad354652366577b4f98213cf76305067144f7b100"},
-    {file = "regex-2020.9.27-cp37-cp37m-win32.whl", hash = "sha256:eda4771e0ace7f67f58bc5b560e27fb20f32a148cbc993b0c3835970935c2707"},
-    {file = "regex-2020.9.27-cp37-cp37m-win_amd64.whl", hash = "sha256:60b0e9e6dc45683e569ec37c55ac20c582973841927a85f2d8a7d20ee80216ab"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_i686.whl", hash = "sha256:088afc8c63e7bd187a3c70a94b9e50ab3f17e1d3f52a32750b5b77dbe99ef5ef"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:eaf548d117b6737df379fdd53bdde4f08870e66d7ea653e230477f071f861121"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:41bb65f54bba392643557e617316d0d899ed5b4946dccee1cb6696152b29844b"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637"},
-    {file = "regex-2020.9.27-cp38-cp38-win32.whl", hash = "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"},
-    {file = "regex-2020.9.27-cp38-cp38-win_amd64.whl", hash = "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c"},
-    {file = "regex-2020.9.27.tar.gz", hash = "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d"},
+    {file = "regex-2020.10.11-cp27-cp27m-win32.whl", hash = "sha256:4f5c0fe46fb79a7adf766b365cae56cafbf352c27358fda811e4a1dc8216d0db"},
+    {file = "regex-2020.10.11-cp27-cp27m-win_amd64.whl", hash = "sha256:39a5ef30bca911f5a8a3d4476f5713ed4d66e313d9fb6755b32bec8a2e519635"},
+    {file = "regex-2020.10.11-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:7c4fc5a8ec91a2254bb459db27dbd9e16bba1dabff638f425d736888d34aaefa"},
+    {file = "regex-2020.10.11-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d537e270b3e6bfaea4f49eaf267984bfb3628c86670e9ad2a257358d3b8f0955"},
+    {file = "regex-2020.10.11-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:a8240df4957a5b0e641998a5d78b3c4ea762c845d8cb8997bf820626826fde9a"},
+    {file = "regex-2020.10.11-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:4302153abb96859beb2c778cc4662607a34175065fc2f33a21f49eb3fbd1ccd3"},
+    {file = "regex-2020.10.11-cp36-cp36m-win32.whl", hash = "sha256:c077c9d04a040dba001cf62b3aff08fd85be86bccf2c51a770c77377662a2d55"},
+    {file = "regex-2020.10.11-cp36-cp36m-win_amd64.whl", hash = "sha256:46ab6070b0d2cb85700b8863b3f5504c7f75d8af44289e9562195fe02a8dd72d"},
+    {file = "regex-2020.10.11-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:d629d750ebe75a88184db98f759633b0a7772c2e6f4da529f0027b4a402c0e2f"},
+    {file = "regex-2020.10.11-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e7ef296b84d44425760fe813cabd7afbb48c8dd62023018b338bbd9d7d6f2f0"},
+    {file = "regex-2020.10.11-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:e490f08897cb44e54bddf5c6e27deca9b58c4076849f32aaa7a0b9f1730f2c20"},
+    {file = "regex-2020.10.11-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:850339226aa4fec04916386577674bb9d69abe0048f5d1a99f91b0004bfdcc01"},
+    {file = "regex-2020.10.11-cp37-cp37m-win32.whl", hash = "sha256:60c4f64d9a326fe48e8738c3dbc068e1edc41ff7895a9e3723840deec4bc1c28"},
+    {file = "regex-2020.10.11-cp37-cp37m-win_amd64.whl", hash = "sha256:8ba3efdd60bfee1aa784dbcea175eb442d059b576934c9d099e381e5a9f48930"},
+    {file = "regex-2020.10.11-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2308491b3e6c530a3bb38a8a4bb1dc5fd32cbf1e11ca623f2172ba17a81acef1"},
+    {file = "regex-2020.10.11-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b8806649983a1c78874ec7e04393ef076805740f6319e87a56f91f1767960212"},
+    {file = "regex-2020.10.11-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a2a31ee8a354fa3036d12804730e1e20d58bc4e250365ead34b9c30bbe9908c3"},
+    {file = "regex-2020.10.11-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9d53518eeed12190744d366ec4a3f39b99d7daa705abca95f87dd8b442df4ad"},
+    {file = "regex-2020.10.11-cp38-cp38-win32.whl", hash = "sha256:3d5a8d007116021cf65355ada47bf405656c4b3b9a988493d26688275fde1f1c"},
+    {file = "regex-2020.10.11-cp38-cp38-win_amd64.whl", hash = "sha256:f579caecbbca291b0fcc7d473664c8c08635da2f9b1567c22ea32311c86ef68c"},
+    {file = "regex-2020.10.11-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8c8c42aa5d3ac9a49829c4b28a81bebfa0378996f9e0ca5b5ab8a36870c3e5ee"},
+    {file = "regex-2020.10.11-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c529ba90c1775697a65b46c83d47a2d3de70f24d96da5d41d05a761c73b063af"},
+    {file = "regex-2020.10.11-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:6cf527ec2f3565248408b61dd36e380d799c2a1047eab04e13a2b0c15dd9c767"},
+    {file = "regex-2020.10.11-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:671c51d352cfb146e48baee82b1ee8d6ffe357c292f5e13300cdc5c00867ebfc"},
+    {file = "regex-2020.10.11-cp39-cp39-win32.whl", hash = "sha256:a63907332531a499b8cdfd18953febb5a4c525e9e7ca4ac147423b917244b260"},
+    {file = "regex-2020.10.11-cp39-cp39-win_amd64.whl", hash = "sha256:1a16afbfadaadc1397353f9b32e19a65dc1d1804c80ad73a14f435348ca017ad"},
+    {file = "regex-2020.10.11.tar.gz", hash = "sha256:463e770c48da76a8da82b8d4a48a541f314e0df91cbb6d873a341dbe578efafd"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -414,21 +407,21 @@ toml = [
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 yarl = [
-    {file = "yarl-1.5.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:db6db0f45d2c63ddb1a9d18d1b9b22f308e52c83638c26b422d520a815c4b3fb"},
-    {file = "yarl-1.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:17668ec6722b1b7a3a05cc0167659f6c95b436d25a36c2d52db0eca7d3f72593"},
-    {file = "yarl-1.5.1-cp35-cp35m-win32.whl", hash = "sha256:040b237f58ff7d800e6e0fd89c8439b841f777dd99b4a9cca04d6935564b9409"},
-    {file = "yarl-1.5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:f18d68f2be6bf0e89f1521af2b1bb46e66ab0018faafa81d70f358153170a317"},
-    {file = "yarl-1.5.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:c52ce2883dc193824989a9b97a76ca86ecd1fa7955b14f87bf367a61b6232511"},
-    {file = "yarl-1.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ce584af5de8830d8701b8979b18fcf450cef9a382b1a3c8ef189bedc408faf1e"},
-    {file = "yarl-1.5.1-cp36-cp36m-win32.whl", hash = "sha256:df89642981b94e7db5596818499c4b2219028f2a528c9c37cc1de45bf2fd3a3f"},
-    {file = "yarl-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:3a584b28086bc93c888a6c2aa5c92ed1ae20932f078c46509a66dce9ea5533f2"},
-    {file = "yarl-1.5.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:da456eeec17fa8aa4594d9a9f27c0b1060b6a75f2419fe0c00609587b2695f4a"},
-    {file = "yarl-1.5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bc2f976c0e918659f723401c4f834deb8a8e7798a71be4382e024bcc3f7e23a8"},
-    {file = "yarl-1.5.1-cp37-cp37m-win32.whl", hash = "sha256:4439be27e4eee76c7632c2427ca5e73703151b22cae23e64adb243a9c2f565d8"},
-    {file = "yarl-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:48e918b05850fffb070a496d2b5f97fc31d15d94ca33d3d08a4f86e26d4e7c5d"},
-    {file = "yarl-1.5.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9b930776c0ae0c691776f4d2891ebc5362af86f152dd0da463a6614074cb1b02"},
-    {file = "yarl-1.5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b3b9ad80f8b68519cc3372a6ca85ae02cc5a8807723ac366b53c0f089db19e4a"},
-    {file = "yarl-1.5.1-cp38-cp38-win32.whl", hash = "sha256:f379b7f83f23fe12823085cd6b906edc49df969eb99757f58ff382349a3303c6"},
-    {file = "yarl-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:9102b59e8337f9874638fcfc9ac3734a0cfadb100e47d55c20d0dc6087fb4692"},
-    {file = "yarl-1.5.1.tar.gz", hash = "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6"},
+    {file = "yarl-1.6.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:db9eb8307219d7e09b33bcb43287222ef35cbcf1586ba9472b0a4b833666ada1"},
+    {file = "yarl-1.6.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e31fef4e7b68184545c3d68baec7074532e077bd1906b040ecfba659737df188"},
+    {file = "yarl-1.6.0-cp35-cp35m-win32.whl", hash = "sha256:5d84cc36981eb5a8533be79d6c43454c8e6a39ee3118ceaadbd3c029ab2ee580"},
+    {file = "yarl-1.6.0-cp35-cp35m-win_amd64.whl", hash = "sha256:5e447e7f3780f44f890360ea973418025e8c0cdcd7d6a1b221d952600fd945dc"},
+    {file = "yarl-1.6.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:6f6898429ec3c4cfbef12907047136fd7b9e81a6ee9f105b45505e633427330a"},
+    {file = "yarl-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d088ea9319e49273f25b1c96a3763bf19a882cff774d1792ae6fba34bd40550a"},
+    {file = "yarl-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b7c199d2cbaf892ba0f91ed36d12ff41ecd0dde46cbf64ff4bfe997a3ebc925e"},
+    {file = "yarl-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:67c5ea0970da882eaf9efcf65b66792557c526f8e55f752194eff8ec722c75c2"},
+    {file = "yarl-1.6.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:04a54f126a0732af75e5edc9addeaa2113e2ca7c6fce8974a63549a70a25e50e"},
+    {file = "yarl-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fcbe419805c9b20db9a51d33b942feddbf6e7fb468cb20686fd7089d4164c12a"},
+    {file = "yarl-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:c604998ab8115db802cc55cb1b91619b2831a6128a62ca7eea577fc8ea4d3131"},
+    {file = "yarl-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c22607421f49c0cb6ff3ed593a49b6a99c6ffdeaaa6c944cdda83c2393c8864d"},
+    {file = "yarl-1.6.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:7ce35944e8e61927a8f4eb78f5bc5d1e6da6d40eadd77e3f79d4e9399e263921"},
+    {file = "yarl-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c15d71a640fb1f8e98a1423f9c64d7f1f6a3a168f803042eaf3a5b5022fde0c1"},
+    {file = "yarl-1.6.0-cp38-cp38-win32.whl", hash = "sha256:3cc860d72ed989f3b1f3abbd6ecf38e412de722fb38b8f1b1a086315cf0d69c5"},
+    {file = "yarl-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:e32f0fb443afcfe7f01f95172b66f279938fbc6bdaebe294b0ff6747fb6db020"},
+    {file = "yarl-1.6.0.tar.gz", hash = "sha256:61d3ea3c175fe45f1498af868879c6ffeb989d4143ac542163c45538ba5ec21b"},
 ]

--- a/tests/format_util_test.py
+++ b/tests/format_util_test.py
@@ -19,7 +19,7 @@ def test_fobj(discord_mock):
 
     # Using fobj() with integers will call client lookup methods.
     assert (fobj(context.discord(), g=guild_id, c=channel_id, u=user_id) ==
-            '"Mock Guild 0" #mock-channel-0 (Mock Member 0#1000)')
+            '<@Mock Member 0#1000> #mock-channel-0 (Mock Guild 0)')
     context.discord().get_guild.assert_called_with(guild_id)
     context.discord().get_channel.assert_called_with(channel_id)
     context.discord().get_user.assert_called_with(user_id)
@@ -29,11 +29,32 @@ def test_fobj(discord_mock):
         channel=context.discord().guilds[0].channels[0],
         author=context.discord().guilds[0].members[0])
     assert (fobj(client=None, m=m) ==
-            '"Mock Guild 0" #mock-channel-0 (Mock Member 0#1000): '
-            '"Mock content"')
+            '"Mock content" '
+            '<@Mock Member 0#1000> #mock-channel-0 (Mock Guild 0)')
 
     # Verify fobj() will truncate content and normalize whitespace.
     m.content = '   somewhat longer\nmessage content text string here'
     assert (fobj(client=None, m=m) ==
-            '"Mock Guild 0" #mock-channel-0 (Mock Member 0#1000): '
-            '"somewhat longer mess ..."')
+            '"somewhat longer ..." '
+            '<@Mock Member 0#1000> #mock-channel-0 (Mock Guild 0)')
+
+    # Verify fobj() with permissions-type objects.
+    permissions = discord.Permissions(stream=True, read_messages=True)
+    overwrite = discord.PermissionOverwrite(stream=False, read_messages=True)
+    assert fobj(p=1536) == 'read_messages, stream'
+    assert fobj(p=permissions) == 'read_messages, stream'
+    assert fobj(p=overwrite) == 'read_messages=Y, stream=N'
+
+    discord_mock.reset_data(members_per_guild=2)
+    members = context.discord().guilds[0].members
+    overwrites = {
+        members[0]: discord.PermissionOverwrite(stream=1, read_messages=0),
+        members[1]: discord.PermissionOverwrite(stream=0, read_messages=1),
+    }
+    assert (
+        fobj(p=overwrites) ==
+        'read_messages=N, stream=Y for <@Mock Member 0#1000>\n'
+        'read_messages=Y, stream=N for <@Mock Member 1#1001>')
+
+    # Verify fobj() produces reasonable output with all parameters None.
+    assert fobj() == '(None)'


### PR DESCRIPTION
Updates visibility of the thread channel so only people who have clicked the 🧵 reaction on the origin message see it. (Also includes a bunch of changes to logging and related utilities for debugging...)